### PR TITLE
Added info on plugin install location

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ Alternatively you can also install each plugin directly (without adding a tap gl
 ```
 brew install knative-sandbox/kn-plugins/admin
 ```
+By default the installation will place the plugin binary into your `PATH`. You will need to move them to your `~/.config/kn/plugins` directory uless you are using [`lookup-plugins`](https://github.com/knative/client/blob/main/docs/README.md#options) with `kn`.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

Added message to tell user plugins are in PATH and need to be moved to `~/.config/kn/plugins`

- :broom: Update or clean up current behavior