### PR TITLE
adding symlink to plugin in plugin directory

### DIFF
--- a/quickstart.rb
+++ b/quickstart.rb
@@ -20,15 +20,21 @@ class Quickstart < Formula
   end
 
   def install
+    me = `whoami`.strip
     if OS.mac?
+      FileUtils.mkdir_p("/Users/#{me}/.config/kn/plugins")
       FileUtils.mv("kn-quickstart-darwin-amd64", "kn-quickstart")
+      bin.install "kn-quickstart"
+      system "ln -s #{bin}/kn-quickstart /Users/#{me}/.config/kn/plugins"
     else
+      FileUtils.mkdir_p("/home/#{me}/.config/kn/plugins")
       FileUtils.mv("kn-quickstart-linux-amd64", "kn-quickstart")
+      bin.install "kn-quickstart"
+      system "ln -s #{bin}/kn-quickstart /home/#{me}/.config/kn/plugins"
     end
-    bin.install "kn-quickstart"
   end
 
   test do
-    system "#{bin}/kn-quickstart", "version"
+    system "kn", "quickstart", "version"
   end
 end


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- :bug: Makes plugin discoverable by `kn` by adding a symlink to the plugin in `~/.config/kn/plugins` directory

This is take 2 on a fix for #23 . 

Note that this has only been tested on Linux and **needs someone with a Mac to verify that it also works on Mac** before it should be merged.

/hold