### PR TITLE
Rename classes causing quickstart installation to fail

### DIFF
--- a/admin@0.25.rb
+++ b/admin@0.25.rb
@@ -1,6 +1,6 @@
 require 'fileutils'
 
-class Admin < Formula
+class AdminAT025 < Formula
   v = "v0.25.0"
   plugin_name = "admin"
   path_name = "kn-plugin-#{plugin_name}"

--- a/source-kafka@0.25.rb
+++ b/source-kafka@0.25.rb
@@ -1,6 +1,6 @@
 require 'fileutils'
 
-class SourceKafka < Formula
+class SourceKafkaAT025 < Formula
   v = "v0.25.0"
   plugin_name = "source-kafka"
   path_name = "kn-plugin-#{plugin_name}"


### PR DESCRIPTION
# Changes
- Name of class in admin@0.25.rb file
- Name of class in source-kafka@0.25.rb file 