### PR TITLE
Fix version numbers for 1.0

### DIFF
--- a/admin.rb
+++ b/admin.rb
@@ -1,11 +1,11 @@
 require 'fileutils'
 
 class Admin < Formula
-  v = "knative-v1.0.0"
+  v = "v1.0.0"
   plugin_name = "admin"
   path_name = "kn-plugin-#{plugin_name}"
   file_name = "kn-#{plugin_name}"
-  base_url = "https://github.com/knative-sandbox/#{path_name}/releases/download/#{v}"
+  base_url = "https://github.com/knative-sandbox/#{path_name}/releases/download/knative-#{v}"
 
   homepage "https://github.com/knative-sandbox/#{path_name}"
 

--- a/quickstart.rb
+++ b/quickstart.rb
@@ -1,11 +1,11 @@
 require 'fileutils'
 
 class Quickstart < Formula
-  v = "knative-v1.0.0"
+  v = "v1.0.0"
   plugin_name = "quickstart"
   path_name = "kn-plugin-#{plugin_name}"
   file_name = "kn-#{plugin_name}"
-  base_url = "https://github.com/knative-sandbox/#{path_name}/releases/download/#{v}"
+  base_url = "https://github.com/knative-sandbox/#{path_name}/releases/download/knative-#{v}"
 
   homepage "https://github.com/knative-sandbox/#{path_name}"
 

--- a/source-kafka.rb
+++ b/source-kafka.rb
@@ -1,11 +1,11 @@
 require 'fileutils'
 
 class SourceKafka < Formula
-  v = "knative-v1.0.0"
+  v = "v1.0.0"
   plugin_name = "source-kafka"
   path_name = "kn-plugin-#{plugin_name}"
   file_name = "kn-#{plugin_name}"
-  base_url = "https://github.com/knative-sandbox/#{path_name}/releases/download/#{v}"
+  base_url = "https://github.com/knative-sandbox/#{path_name}/releases/download/knative-#{v}"
 
   homepage "https://github.com/knative-sandbox/#{path_name}"
 

--- a/source-kamelet.rb
+++ b/source-kamelet.rb
@@ -1,11 +1,11 @@
 require 'fileutils'
 
 class SourceKamelet < Formula
-  v = "knative-v1.0.0"
+  v = "v1.0.0"
   plugin_name = "source-kamelet"
   path_name = "kn-plugin-#{plugin_name}"
   file_name = "kn-#{plugin_name}"
-  base_url = "https://github.com/knative-sandbox/#{path_name}/releases/download/#{v}"
+  base_url = "https://github.com/knative-sandbox/#{path_name}/releases/download/knative-#{v}"
 
   homepage "https://github.com/knative-sandbox/#{path_name}"
 


### PR DESCRIPTION
# Changes

This fixes the version numbers for the 1.0 plugin releases, making them v1.0.0 (instead of knative-v1.0.0)