### PR TITLE
Fix classname for 0.26. 

### DIFF
--- a/admin@0.26.rb
+++ b/admin@0.26.rb
@@ -1,6 +1,6 @@
 require 'fileutils'
 
-class AdminAT26 < Formula
+class AdminAT026 < Formula
   v = "v0.26.0"
   plugin_name = "admin"
   path_name = "kn-plugin-#{plugin_name}"

--- a/source-kafka@0.26.rb
+++ b/source-kafka@0.26.rb
@@ -1,6 +1,6 @@
 require 'fileutils'
 
-class SourceKafkaAT26 < Formula
+class SourceKafkaAT026 < Formula
   v = "v0.26.0"
   plugin_name = "source-kafka"
   path_name = "kn-plugin-#{plugin_name}"

--- a/source-kamelet@0.26.rb
+++ b/source-kamelet@0.26.rb
@@ -1,6 +1,6 @@
 require 'fileutils'
 
-class SourceKameletAT26 < Formula
+class SourceKameletAT026 < Formula
   v = "v0.26.0"
   plugin_name = "source-kamelet"
   path_name = "kn-plugin-#{plugin_name}"


### PR DESCRIPTION
# Changes

- :bug: Fix can't tap `brew tap knative-sandbox/kn-plugins`

/kind bug

I encountered the error when `brew tap`.
I fixed classname and it worked correctly, so I will send a pull request.
If it's a misguided fix, dismiss it.

```
$ lsb_release  -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 20.04.3 LTS
Release:        20.04
Codename:       focal
```

```
$ brew -v
Homebrew 3.3.2
Homebrew/homebrew-core (git revision 1e9d510578e; last commit 2021-11-03)
```

```
$ brew tap knative-sandbox/kn-plugins
==> Tapping knative-sandbox/kn-plugins
Cloning into '/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/knative-sandbox/homebrew-kn-plugins'...
remote: Enumerating objects: 125, done.
remote: Counting objects: 100% (125/125), done.
remote: Compressing objects: 100% (95/95), done.
remote: Total 125 (delta 85), reused 36 (delta 29), pack-reused 0
Receiving objects: 100% (125/125), 33.13 KiB | 1.74 MiB/s, done.
Resolving deltas: 100% (85/85), done.
Error: Invalid formula: /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/knative-sandbox/homebrew-kn-plugins/admin@0.26.rb
No available formula with the name "admin@0.26". Did you mean admin@0.26, admin@0.25, admin@0.24, admin@0.23, admin@0.22 or admin@0.21?
In formula file: /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/knative-sandbox/homebrew-kn-plugins/admin@0.26.rb
Expected to find class AdminAT026, but only found: AdminAT26.
Error: Invalid formula: /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/knative-sandbox/homebrew-kn-plugins/source-kamelet@0.26.rb
No available formula with the name "source-kamelet@0.26". Did you mean source-kamelet@0.26, source-kamelet or source-kafka@0.26?
In formula file: /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/knative-sandbox/homebrew-kn-plugins/source-kamelet@0.26.rb
Expected to find class SourceKameletAT026, but only found: SourceKameletAT26.
Error: Invalid formula: /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/knative-sandbox/homebrew-kn-plugins/source-kafka@0.26.rb
No available formula with the name "source-kafka@0.26". Did you mean source-kafka@0.26, source-kafka@0.25, source-kafka@0.24, source-kafka@0.23, source-kafka@0.22, source-kafka@0.21 or source-kafka?
In formula file: /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/knative-sandbox/homebrew-kn-plugins/source-kafka@0.26.rb
Expected to find class SourceKafkaAT026, but only found: SourceKafkaAT26.
Error: Cannot tap knative-sandbox/kn-plugins: invalid syntax in tap!
```
