### PR TITLE
chore: bump func from 0.18 to 0.21

### DIFF
--- a/func@0.18.rb
+++ b/func@0.18.rb
@@ -1,6 +1,6 @@
 require 'fileutils'
 
-class Func < Formula
+class FuncAT018 < Formula
   v = "v0.18.0"
   plugin_name = "func"
   path_name = "kn-plugin-#{plugin_name}"

--- a/func@0.18.rb
+++ b/func@0.18.rb
@@ -1,7 +1,7 @@
 require 'fileutils'
 
 class Func < Formula
-  v = "v0.21.2"
+  v = "v0.18.0"
   plugin_name = "func"
   path_name = "kn-plugin-#{plugin_name}"
   file_name = "#{plugin_name}"
@@ -12,11 +12,11 @@ class Func < Formula
   version v
 
   if OS.mac?
-    url "#{base_url}/#{file_name}_darwin_amd64"
-    sha256 "2d21429d8c9d8b7a4fda958ec210765ec8d03729cd130a68ab6a6d0c50a29479"
+    url "#{base_url}/#{file_name}_darwin_amd64.gz"
+    sha256 "3d1de7fe30cb7a21581f0dd7e554b19b7c343dc43ac555eff9512545fd78722c"
   else
-    url "#{base_url}/#{file_name}_linux_amd64"
-    sha256 "70d22e96cde36809e9681b7cec891f0a63d96c84a4eede0de727aadca42bd363"
+    url "#{base_url}/#{file_name}_linux_amd64.gz"
+    sha256 "a332f007531c8ac1ef3fa73e330ea8682e84cffe9a2070dd3af7835380b8553f"
   end
 
   def install

--- a/func@0.19.rb
+++ b/func@0.19.rb
@@ -1,6 +1,6 @@
 require 'fileutils'
 
-class Func < Formula
+class FuncAT019 < Formula
   v = "v0.19.0"
   plugin_name = "func"
   path_name = "kn-plugin-#{plugin_name}"

--- a/func@0.19.rb
+++ b/func@0.19.rb
@@ -1,7 +1,7 @@
 require 'fileutils'
 
 class Func < Formula
-  v = "v0.21.2"
+  v = "v0.19.0"
   plugin_name = "func"
   path_name = "kn-plugin-#{plugin_name}"
   file_name = "#{plugin_name}"
@@ -12,11 +12,11 @@ class Func < Formula
   version v
 
   if OS.mac?
-    url "#{base_url}/#{file_name}_darwin_amd64"
-    sha256 "2d21429d8c9d8b7a4fda958ec210765ec8d03729cd130a68ab6a6d0c50a29479"
+    url "#{base_url}/#{file_name}_darwin_amd64.gz"
+    sha256 "42d6f491a2cead97a5fe70a20ada0580acbcddb36628f3571c2afe73e6d6a852"
   else
-    url "#{base_url}/#{file_name}_linux_amd64"
-    sha256 "70d22e96cde36809e9681b7cec891f0a63d96c84a4eede0de727aadca42bd363"
+    url "#{base_url}/#{file_name}_linux_amd64.gz"
+    sha256 "36a3631f79fea45ec9b6958a559fd74947ad562bdc1d7f23548e51aa322d4c3b"
   end
 
   def install

--- a/func@0.20.rb
+++ b/func@0.20.rb
@@ -1,6 +1,6 @@
 require 'fileutils'
 
-class Func < Formula
+class FuncAT020 < Formula
   v = "v0.20.0"
   plugin_name = "func"
   path_name = "kn-plugin-#{plugin_name}"

--- a/func@0.20.rb
+++ b/func@0.20.rb
@@ -1,7 +1,7 @@
 require 'fileutils'
 
 class Func < Formula
-  v = "v0.21.2"
+  v = "v0.20.0"
   plugin_name = "func"
   path_name = "kn-plugin-#{plugin_name}"
   file_name = "#{plugin_name}"
@@ -13,10 +13,10 @@ class Func < Formula
 
   if OS.mac?
     url "#{base_url}/#{file_name}_darwin_amd64"
-    sha256 "2d21429d8c9d8b7a4fda958ec210765ec8d03729cd130a68ab6a6d0c50a29479"
+    sha256 "55713f462b229d2de95d79ef38bc61131ddfb7c4ec2e90d3e670349ee4baa564"
   else
     url "#{base_url}/#{file_name}_linux_amd64"
-    sha256 "70d22e96cde36809e9681b7cec891f0a63d96c84a4eede0de727aadca42bd363"
+    sha256 "d5a08cc7b9e2f1036072ca03cbc83b462c22f356e520b1aa94a7582acf16af1a"
   end
 
   def install


### PR DESCRIPTION

# Changes

- :broom: add formulae for versions 0.19, 0.20 and 0.21
- :broom: make func 0.21.2 the latest

/kind enhancement

Fixes: https://github.com/knative-sandbox/kn-plugin-func/issues/794

**Release Note**
```release-note
Adds versions 0.19, 0.20 and 0.21 of func
```
