### PR TITLE
Update func@0.22 class name

### DIFF
--- a/func@0.22.rb
+++ b/func@0.22.rb
@@ -1,6 +1,6 @@
 require 'fileutils'
 
-class Func < Formula
+class FuncAT022 < Formula
   v = "v0.22.0"
   plugin_name = "func"
   path_name = "kn-plugin-#{plugin_name}"


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

Fixes func v0.22 class name, as reported on [slack](https://knative.slack.com/archives/C93E33SN8/p1651680647100459)

