### PR TITLE
Add homebrew-kn-plugins-approvers to owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,7 @@ approvers:
 - client-writers
 - technical-oversight-committee
 - knative-release-leads
+- homebrew-kn-plugins-approvers
 reviewers:
 - client-writers
 


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

Assuming the approvers group named after the repo should be in the OWNERS file :smile: 

/assign @rhuss @dsimansk 