### PR TITLE
Add script to update plugin versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The supported client plugins are:
 * [kn-plugin-func](https://github.com/knative-sandbox/kn-plugin-func) - The Functions plugin
 * [kn-plugin-quickstart](https://github.com/knative-sandbox/kn-plugin-quickstart) - The Quickstart plugin
 * [kn-plugin-source-kafka](https://github.com/knative-sandbox/kn-plugin-source-kafka) - The source Kafka plugin
+* [kn-plugin-source-kamelet](https://github.com/knative-sandbox/kn-plugin-source-kamelet) - The source Kamelet plugin
 * [kn-plugin-event](https://github.com/knative-sandbox/kn-plugin-event) - Sending events to Knative sinks
 
 
@@ -28,3 +29,9 @@ Alternatively you can also install each plugin directly (without adding a tap gl
 ```
 brew install knative-sandbox/kn-plugins/admin
 ```
+
+## Updating Plugin Versions
+
+To update plugins that are part of the [release train](https://github.com/knative/release/blob/main/INSTRUCTIONS.md#homebrew-kn-plugins), update the `PREVIOUS_RELEASE` / `CURRENT_RELEASE` variables in the `./hack/update-versions.sh` script, then run the script locally and push a PR with the changes. 
+
+For plugins not on the release train, updates will need to be done manually, as for example in [this PR](https://github.com/knative-sandbox/homebrew-kn-plugins/pull/92). 

--- a/hack/update-versions.sh
+++ b/hack/update-versions.sh
@@ -1,0 +1,64 @@
+#! /usr/bin/env bash
+
+# Copyright 2022 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+PLUGINS=("admin" "event" "quickstart" "source-kafka" "source-kamelet")
+CURRENT_RELEASE=1.5
+PREVIOUS_RELEASE=1.4
+
+for plugin in "${PLUGINS[@]}"; do
+
+    echo "Updating kn-$plugin from $PREVIOUS_RELEASE to $CURRENT_RELEASE"
+    newfile="${plugin}.rb"
+    oldfile="${plugin}@${PREVIOUS_RELEASE}.rb"
+
+    echo "Create formula for previous release"
+    cp "$newfile" "$oldfile"
+    class_version=${PREVIOUS_RELEASE//.}
+    if [[ $plugin =~ "-" ]]; then
+        classparts="$plugin"
+        IFS='-'
+        read -ra classnameparts <<< $classparts
+        class_name="${classnameparts[0]^}${classnameparts[1]^}"
+        unset IFS
+    else
+        class_name=${plugin^}
+    fi
+    sed -i 's/class '${class_name}' < Formula/class '${class_name}'AT'$class_version' < Formula/' "$oldfile"
+    echo "$oldfile created"
+
+    echo "Creating formula for current release"
+    #sed -i 's/v = "v'$PREVIOUS_RELEASE'/v = "v'$CURRENT_RELEASE'/' $newfile
+    sed -i 's/v'${PREVIOUS_RELEASE}'/v'$CURRENT_RELEASE'/g' "$newfile"
+
+    # change shas for mac and linux
+    checksums=$(mktemp)
+    old_checksums=$(mktemp)
+    curl -L "https://github.com/knative-sandbox/kn-plugin-${plugin}/releases/download/knative-v${CURRENT_RELEASE}.0/checksums.txt" > "$checksums"
+    curl -L "https://github.com/knative-sandbox/kn-plugin-${plugin}/releases/download/knative-v${PREVIOUS_RELEASE}.0/checksums.txt" > "$old_checksums"
+    darwin_checksum=$(awk '$2=="kn-'"$plugin"'-darwin-amd64"{print $1}' $checksums)
+    darwin_old_checksum=$(awk '$2=="kn-'"$plugin"'-darwin-amd64"{print $1}' $old_checksums)
+    sed -i 's/sha256 "'$darwin_old_checksum'"/sha256 "'$darwin_checksum'"/' "$newfile"
+    linux_checksum=$(awk '$2=="kn-'"$plugin"'-linux-amd64"{print $1}' $checksums)
+    linux_old_checksum=$(awk '$2=="kn-'"$plugin"'-linux-amd64"{print $1}' $old_checksums)
+    sed -i 's/sha256 "'$linux_old_checksum'"/sha256 "'$linux_checksum'"/' "$newfile"
+
+    echo "$newfile created"
+
+done 
+
+echo "Have a nice day!"


### PR DESCRIPTION
# Changes

Fixs #6 

This PR adds a script that does the version updates for all the plugins in the release train. As of now, it needs to run manually from someone's personal machine, but down the line we can move it to a GH Action so it's fully automated. 

All the release lead will need to do is bump the versions in the script, then run the script, then push a PR with the changes. I've tested it out locally, and it worked fine for the most recent release (v1.4 => v1.5). 

That said, please do review carefully :pray: 

If we're happy with this, should be easy to port over to the client homebrew repo as well.

/assign @knative-sandbox/client-writers @knative-sandbox/homebrew-kn-plugins-approvers 
/cc @csantanapr 