### PR TITLE
chore: do not use `knative-` as a prefix

### DIFF
--- a/func.rb
+++ b/func.rb
@@ -1,11 +1,11 @@
 require 'fileutils'
 
 class Func < Formula
-  v = "knative-v1.7.0"
+  v = "v1.7.0"
   plugin_name = "func"
   path_name = "kn-plugin-#{plugin_name}"
   file_name = "#{plugin_name}"
-  base_url = "https://github.com/knative-sandbox/#{path_name}/releases/download/#{v}"
+  base_url = "https://github.com/knative-sandbox/#{path_name}/releases/download/knative-#{v}"
 
   homepage "https://github.com/knative-sandbox/#{path_name}"
 


### PR DESCRIPTION
Not really sure how the `kn` client avoids this, but it seems like I was mistaken about the fact that using `knative-` as a prefix would just be fine.

Signed-off-by: Lance Ball <lball@redhat.com>

